### PR TITLE
Correções Mobile 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,6 @@
         "@fortawesome/vue-fontawesome": "^3.0.8",
         "bootstrap": "^5.3.3",
         "emailjs-com": "^3.2.0",
-        "locomotive-scroll": "^4.1.4",
         "pinia": "^3.0.1",
         "typewriter-effect": "^2.21.0",
         "vue": "^3.5.13",
@@ -1755,18 +1754,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/bezier-easing": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/bezier-easing/-/bezier-easing-2.1.0.tgz",
-      "integrity": "sha512-gbIqZ/eslnUFC1tjEvtz0sgx+xTK20wDnYMIA27VA04R7w6xxXQPZDbibjA9DTWZRA2CXtwHykkVzlCaAJAZig==",
-      "license": "MIT"
-    },
-    "node_modules/bindall-standalone": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/bindall-standalone/-/bindall-standalone-1.0.5.tgz",
-      "integrity": "sha512-HDI7YBWXVJk/eoGz+e4lYQQJnYp1ZHcUvAY71lVptLMhQnDm86vD73AGPw2qIlgYR3P0bjmoAcXiA8qhFejBhA==",
-      "license": "MIT"
-    },
     "node_modules/birpc": {
       "version": "0.2.19",
       "resolved": "https://registry.npmjs.org/birpc/-/birpc-0.2.19.tgz",
@@ -2422,23 +2409,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/lethargy": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/lethargy/-/lethargy-1.0.9.tgz",
-      "integrity": "sha512-nFM8blpCF9rqIL5mRAaTGc78W8oQixVtsD86jbEPvcI13+lDUYJf3R7DZQQL7tCiBpbGpGKMX2gwJFO9hiaOkg==",
-      "license": "MIT"
-    },
-    "node_modules/locomotive-scroll": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/locomotive-scroll/-/locomotive-scroll-4.1.4.tgz",
-      "integrity": "sha512-6i98cFF2SKg6wIPpwVPuo2FG8qL3USsdDeew78TEYZyLoqleMWNfkSDpWA6mPym4dOfTIBXc678VmGlkgx3fTA==",
-      "license": "MIT",
-      "dependencies": {
-        "bezier-easing": "^2.1.0",
-        "smoothscroll-polyfill": "^0.4.4",
-        "virtual-scroll": "^1.5.2"
-      }
-    },
     "node_modules/loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -3016,12 +2986,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/smoothscroll-polyfill": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/smoothscroll-polyfill/-/smoothscroll-polyfill-0.4.4.tgz",
-      "integrity": "sha512-TK5ZA9U5RqCwMpfoMq/l1mrH0JAR7y7KRvOBx0n2869aLxch+gT9GhN3yUfjiw+d/DiF1mKo14+hd62JyMmoBg==",
-      "license": "MIT"
-    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -3064,12 +3028,6 @@
       "engines": {
         "node": ">=16"
       }
-    },
-    "node_modules/tiny-emitter": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-1.2.0.tgz",
-      "integrity": "sha512-rWjF00inHeWtT5UbQYAXoMI4hL6TRMqohuKCsODyPYYmfAxqfMnXLsIeNrbdPEkNxlk++rojVilTnI9IVmEBtA==",
-      "license": "MIT"
     },
     "node_modules/totalist": {
       "version": "3.0.1",
@@ -3168,18 +3126,6 @@
       },
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
-      }
-    },
-    "node_modules/virtual-scroll": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/virtual-scroll/-/virtual-scroll-1.5.2.tgz",
-      "integrity": "sha512-7jDHwlKbHUho7CYU/HojE/VKFH8GV9P5fVWP2HCa7dRUOpVvwl93OBOKIIcb2mKd+vqsbVR/0zl0X70+3sUZqA==",
-      "license": "MIT",
-      "dependencies": {
-        "bindall-standalone": "^1.0.5",
-        "lethargy": "^1.0.2",
-        "object-assign": "^4.0.1",
-        "tiny-emitter": "^1.0.0"
       }
     },
     "node_modules/vite": {

--- a/src/components/ContactFormComponent.vue
+++ b/src/components/ContactFormComponent.vue
@@ -281,6 +281,7 @@ const handleSubmit = async () => {
   align-items: center;
   justify-content: center;
   gap: 0.5rem;
+  min-height: 48px;
   margin-top: 0.5rem;
   padding: 0.9rem 1.75rem;
   font-size: 0.85rem;
@@ -332,6 +333,12 @@ const handleSubmit = async () => {
 
   .form-card__row {
     grid-template-columns: 1fr;
+  }
+
+  .form-card__field input,
+  .form-card__field select,
+  .form-card__field textarea {
+    font-size: 16px;
   }
 }
 

--- a/src/components/NavbarComponent.vue
+++ b/src/components/NavbarComponent.vue
@@ -237,6 +237,10 @@ onUnmounted(() => {
 
 .navbar-toggle {
   display: none;
+  align-items: center;
+  justify-content: center;
+  min-width: 48px;
+  min-height: 48px;
   background: none;
   border: none;
   color: var(--text-color);
@@ -385,7 +389,7 @@ onUnmounted(() => {
   }
 
   .navbar-toggle {
-    display: block;
+    display: flex;
   }
 }
 </style>

--- a/src/components/hero/HeroFloatingCard.vue
+++ b/src/components/hero/HeroFloatingCard.vue
@@ -79,4 +79,27 @@ defineProps<{
   color: var(--text-color);
   white-space: nowrap;
 }
+
+@media (max-width: 900px) {
+  .hero-card {
+    padding: 0.55rem 0.7rem;
+    gap: 0.5rem;
+  }
+
+  .hero-card__icon {
+    width: 1.75rem;
+    height: 1.75rem;
+    font-size: 0.8rem;
+  }
+
+  .hero-card__label {
+    font-size: 0.56rem;
+  }
+
+  .hero-card__value {
+    font-size: 0.74rem;
+    white-space: normal;
+    line-height: 1.3;
+  }
+}
 </style>

--- a/src/components/projects/ProjectSpotlightShowcase.vue
+++ b/src/components/projects/ProjectSpotlightShowcase.vue
@@ -434,6 +434,7 @@ watch(
     padding-right: 0;
     padding-bottom: 0.15rem;
     scrollbar-width: none;
+    scroll-snap-type: x proximity;
   }
 
   .spotlight__rail::-webkit-scrollbar {
@@ -443,6 +444,7 @@ watch(
   .spotlight__rail-item {
     flex: 0 0 auto;
     min-width: 11.5rem;
+    scroll-snap-align: center;
     transform: none;
   }
 
@@ -459,8 +461,8 @@ watch(
   }
 
   .spotlight__arrow {
-    width: 2.5rem;
-    height: 2.5rem;
+    width: 3rem;
+    height: 3rem;
     border-radius: 50%;
     border: 1px solid rgba(var(--section-accent-rgb, 118, 192, 70), 0.35);
     background: rgba(var(--section-accent-rgb, 118, 192, 70), 0.08);

--- a/src/views/Contact.vue
+++ b/src/views/Contact.vue
@@ -220,6 +220,8 @@ const scrollToForm = () => {
 .contact-cta {
   display: inline-flex;
   align-items: center;
+  justify-content: center;
+  min-height: 48px;
   gap: 0.6rem;
   padding: 0.75rem 1.35rem;
   border-radius: 0.6rem;

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -214,6 +214,7 @@ watch(locale, () => initTypewriter())
   display: inline-flex;
   align-items: center;
   justify-content: center;
+  min-height: 48px;
   padding: 0.7rem 1.35rem;
   border-radius: 0.5rem;
   font-weight: 600;
@@ -268,6 +269,11 @@ watch(locale, () => initTypewriter())
 }
 
 .hero-social a {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 44px;
+  min-height: 44px;
   color: rgba(237, 238, 237, 0.7);
   font-size: 1.2rem;
   transition: color 0.3s ease, transform 0.2s ease;
@@ -375,9 +381,15 @@ watch(locale, () => initTypewriter())
 }
 
 @media (max-width: 900px) {
+  .hero {
+    height: auto;
+    overflow: visible;
+  }
+
   .hero-inner {
+    height: auto;
     padding-top: 4.75rem;
-    justify-content: center;
+    justify-content: flex-start;
   }
 
   .hero-content {
@@ -397,6 +409,11 @@ watch(locale, () => initTypewriter())
 
   .hero-float--stack {
     display: none;
+  }
+
+  .hero-float--exp,
+  .hero-float--projects {
+    max-width: 46%;
   }
 
   .hero-float--exp {
@@ -422,6 +439,17 @@ watch(locale, () => initTypewriter())
   .hero-ctas .btn-cta-primary,
   .hero-ctas .btn-cta-outline {
     flex: 1 1 auto;
+  }
+}
+
+@media (max-width: 480px) {
+  .hero-ctas {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .hero-ctas .btn-cta {
+    width: 100%;
   }
 }
 

--- a/src/views/PortfolioView.vue
+++ b/src/views/PortfolioView.vue
@@ -37,6 +37,7 @@ import FooterComponent from '@/components/FooterComponent.vue'
 .fullpage-container {
   scroll-snap-type: y mandatory;
   overflow-y: auto;
+  overflow-x: hidden;
   height: 100vh;
 }
 
@@ -82,15 +83,6 @@ import FooterComponent from '@/components/FooterComponent.vue'
   overflow: hidden;
 }
 
-@media (max-width: 900px) {
-  .section--about-premium {
-    height: auto;
-    min-height: 100vh;
-    max-height: none;
-    overflow: visible;
-  }
-}
-
 .section--experience {
   width: 100%;
   align-items: center;
@@ -107,5 +99,17 @@ import FooterComponent from '@/components/FooterComponent.vue'
   height: 100vh;
   max-height: 100vh;
   min-height: 100vh;
+}
+
+@media (max-width: 900px) {
+  .section--home,
+  .section--projects,
+  .section--about-premium,
+  .section--contact {
+    height: auto;
+    min-height: 100vh;
+    max-height: none;
+    overflow: visible;
+  }
 }
 </style>

--- a/src/views/Projects.vue
+++ b/src/views/Projects.vue
@@ -93,13 +93,16 @@ const { projects } = useProjects()
   color: var(--section-accent, var(--tertiary-color));
 }
 
-@media (max-width: 768px) {
+@media (max-width: 900px) {
   .projects-section {
+    height: auto;
+    overflow: visible;
     padding: 4.5rem 0 1.25rem;
     align-items: stretch;
   }
 
   .projects-section__inner {
+    height: auto;
     gap: 0.85rem;
   }
 }


### PR DESCRIPTION
 as seções Home, Projects e Contact em PortfolioView.vue estavam com height: 100vh; overflow: hidden fixos, mesmo no mobile — um resquício do design "fullpage scroll" pensado pra desktop. Isso cortava silenciosamente qualquer conteúdo que não coubesse em uma tela de celular:
- Contato: o formulário real media ~1260px de altura, mas a seção travava em 667px e escondia (overflow:hidden) quase metade — inputs, textarea e botão de envio ficavam invisíveis/inacessíveis.
- Home: o conteúdo do hero (736px) não cabia nos 667px da seção; como o container centralizava tudo verticalmente, o topo (onde ficam os cards flutuantes "Experience"/"Projects") era cortado, dando a impressão de ícones "bugados".

Correções aplicadas:
1. PortfolioView.vue — seções home, projects, about, contact agora usam height:auto + overflow:visible no mobile (< 900px), crescendo conforme o conteúdo real (o About já tinha esse tratamento; estendi para as outras). (Bug extra que encontrei nesse processo: minha primeira tentativa dessa correção ficou antes da regra base .section--contact no arquivo — como CSS empata em especificidade, quem vem depois na ordem do arquivo vence, então a regra antiga sobrescrevia a minha. Corrigido movendo a media query pro fim do bloco.)
2. Home.vue — além do container, os dois cards flutuantes (hero-float--exp/--projects) tinham largura livre (texto sem quebra), e ambos ficavam grudados nas bordas (left:0/right:0), causando sobreposição de até ~120px em telas de 320px. Agora têm max-width:46% e a HeroFloatingCard.vue permite quebra de linha no texto em mobile.
3. Projects.vue — alinhei o breakpoint de 768px→900px para bater com o breakpoint interno do carrossel, e apliquei o mesmo tratamento de altura automática.